### PR TITLE
Naming Convention Fix for Drive Team

### DIFF
--- a/frontend/src/components/AdminTeamMatches.tsx
+++ b/frontend/src/components/AdminTeamMatches.tsx
@@ -118,6 +118,8 @@ const getMatchLabel = (match: Record<string, unknown>) => {
   const matchNumber = Number(match.match_number || 0);
 
   if (compLevel === 'QM') return `QM${matchNumber}`;
+  if (compLevel === 'SF') return `SF${setNumber}`;
+  if (compLevel === 'F') return `F${matchNumber}`;
   if (setNumber > 0) return `${compLevel}${setNumber}-${matchNumber}`;
   return `${compLevel}${matchNumber}`;
 };

--- a/frontend/src/components/MatchSchedule.tsx
+++ b/frontend/src/components/MatchSchedule.tsx
@@ -74,7 +74,17 @@ const getAllianceTeams = (match: any, alliance: 'red' | 'blue'): string[] => {
   return [];
 };
 
-const getMatchLabel = (match: any) => `${match.comp_level || ''}${match.match_number || (match.key ? match.key.split('m')[1] : '')}`;
+const getMatchLabel = (match: any) => {
+  const compLevel = String(match.comp_level || '').toUpperCase();
+  const setNumber = Number(match.set_number || 0);
+  const matchNumber = match.match_number || (match.key ? match.key.split('m')[1] : '');
+
+  if (compLevel === 'QM') return `QM${matchNumber}`;
+  if (compLevel === 'SF') return `SF${setNumber}`;
+  if (compLevel === 'F') return `F${matchNumber}`;
+  if (setNumber > 0) return `${compLevel}${setNumber}-${matchNumber}`;
+  return `${compLevel}${matchNumber}`;
+};
 
 const matchFieldRegex = /match( number| #|#|num| no\.?|)/i;
 


### PR DESCRIPTION
Fixed naming conventions for SF and F in drive team tab for drive team accounts.